### PR TITLE
The static entity manager instance is removed.

### DIFF
--- a/library/src/main/java/com/sap/hana/cloud/samples/adapters/PersistenceAdapter.java
+++ b/library/src/main/java/com/sap/hana/cloud/samples/adapters/PersistenceAdapter.java
@@ -25,7 +25,6 @@ public class PersistenceAdapter {
 	private static final Logger LOGGER = LoggerFactory.getLogger(PersistenceAdapter.class);
 
 	private static EntityManagerFactory emf;
-	private static EntityManager em;
 
 	/**
 	 * This method returns an {@link javax.persistence.EntityManager EntityManager} instance.
@@ -37,11 +36,7 @@ public class PersistenceAdapter {
 			init();
 		}
 
-		if (em == null) {
-			em = emf.createEntityManager();
-		}
-
-		return em;
+		return emf.createEntityManager();
 	}
 
 


### PR DESCRIPTION
Instead a new entity manager instance is created each time.
This is because the entity manager is not thread safe so it should not be a single static instance.
